### PR TITLE
test: reorganize tests and fix Reports test issues and create Settings unit test

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -98,6 +98,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -437,6 +438,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -460,6 +462,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -579,6 +582,7 @@
       "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.14.0.tgz",
       "integrity": "sha512-O000MLDBDdk/EohJPFUqvnp4qnHeYkVP5B0xEG0D/L7cOKP9kefu2DXn8dj74cQfsEzUqh+sr1RzFqiL1o+PpA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.13.5",
@@ -622,6 +626,7 @@
       "resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-11.14.1.tgz",
       "integrity": "sha512-qEEJt42DuToa3gurlH4Qqc1kVpNq8wO8cJtDzU46TjlzWjDlsVyevtYCRijVq3SrHsROS+gVQ8Fnea108GnKzw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.13.5",
@@ -1405,6 +1410,7 @@
       "resolved": "https://registry.npmjs.org/@mui/material/-/material-7.3.8.tgz",
       "integrity": "sha512-QKd1RhDXE1hf2sQDNayA9ic9jGkEgvZOf0tTkJxlBPG8ns8aS4rS8WwYURw2x5y3739p0HauUXX9WbH7UufFLw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.28.6",
         "@mui/core-downloads-tracker": "^7.3.8",
@@ -2146,8 +2152,7 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -2316,6 +2321,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.13.tgz",
       "integrity": "sha512-KkiJeU6VbYbUOp5ITMIc7kBfqlYkKA5KhEHVrGMmUUMt7NeaZg65ojdPk+FtNrBAOXNVM5QM72jnADjM+XVRAQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2326,6 +2332,7 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -2422,6 +2429,7 @@
       "integrity": "sha512-4z2nCSBfVIMnbuu8uinj+f0o4qOeggYJLbjpPHka3KH1om7e+H9yLKTYgksTaHcGco+NClhhY2vyO3HsMH1RGw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.55.0",
         "@typescript-eslint/types": "8.55.0",
@@ -2566,9 +2574,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2788,6 +2796,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3109,9 +3118,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3148,6 +3157,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3563,9 +3573,9 @@
       }
     },
     "node_modules/cosmiconfig/node_modules/yaml": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
-      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
+      "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
       "license": "ISC",
       "engines": {
         "node": ">= 6"
@@ -3933,8 +3943,7 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/dom-helpers": {
       "version": "5.2.1",
@@ -4002,6 +4011,7 @@
       "integrity": "sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-colors": "^4.1.1",
         "strip-ansi": "^6.0.1"
@@ -4168,6 +4178,7 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -5263,6 +5274,7 @@
       "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssstyle": "^4.2.1",
         "data-urls": "^5.0.0",
@@ -5486,9 +5498,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "dev": true,
       "license": "MIT"
     },
@@ -5610,7 +5622,6 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -6038,11 +6049,12 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6123,7 +6135,6 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -6139,7 +6150,6 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -6152,8 +6162,7 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/process": {
       "version": "0.11.10",
@@ -6231,6 +6240,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6240,6 +6250,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -6251,13 +6262,15 @@
       "version": "19.2.4",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.4.tgz",
       "integrity": "sha512-W+EWGn2v0ApPKgKKCy/7s7WHXkboGcsrXE+2joLyVxkbyVQfO3MUEaUQDHoSmb8TFFrSKYa9mw64WZHNHSDzYA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/react-redux": {
       "version": "9.2.0",
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
       "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",
         "use-sync-external-store": "^1.4.0"
@@ -6388,7 +6401,8 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/redux-thunk": {
       "version": "3.1.0",
@@ -7185,6 +7199,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -7362,11 +7377,12 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
-      "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
+      "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -7788,6 +7804,7 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/frontend/src/_tests_/Login.test.tsx
+++ b/frontend/src/_tests_/Login.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { MemoryRouter, Route, Routes } from 'react-router-dom'
-import Login from './Login'
+import Login from '../pages/Login'
 import { loginUser } from '../lib/api'
 import { setAuthSession } from '../lib/auth'
 

--- a/frontend/src/_tests_/Reports.test.tsx
+++ b/frontend/src/_tests_/Reports.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import Reports from './Reports'
+import Reports from '../pages/Reports'
 import { fetchSales, type SaleRecord } from '../lib/api'
 import { RestaurantContext } from '../context/RestaurantContext'
 import type { RestaurantContextType } from '../context/RestaurantContext'
@@ -112,12 +112,15 @@ describe('Reports page', () => {
     await user.click(screen.getByRole('combobox', { name: /month/i }))
     await user.click(await screen.findByRole('option', { name: 'March' }))
 
-    expect(await screen.findByText('March 2026')).toBeInTheDocument()
+    expect(await screen.findByText(/March\s+2026/i)).toBeInTheDocument()
     expect(screen.getAllByText('TOTAL').length).toBeGreaterThan(0)
     expect(screen.getByText('CREDIT')).toBeInTheDocument()
-    expect(screen.getByText((content) => content.includes('200'))).toBeInTheDocument()
-    expect(screen.getByText((content) => content.includes('500'))).toBeInTheDocument()
-    expect(screen.getByText((content) => content.includes('150'))).toBeInTheDocument()
+    expect(screen.getAllByText((content) => content.includes("200")).length).toBeGreaterThan(0)
+    expect(screen.getAllByText((content) => content.includes("500")).length).toBeGreaterThan(0)
+    expect(screen.getAllByText((content) => content.includes("150")).length).toBeGreaterThan(0)
+   // expect(screen.getByText((content) => content.includes('200'))).toBeInTheDocument()
+   // expect(screen.getByText((content) => content.includes('500'))).toBeInTheDocument()
+   // expect(screen.getByText((content) => content.includes('150'))).toBeInTheDocument()
   })
 
   it('refetches reports for a selected restaurant', async () => {
@@ -132,7 +135,7 @@ describe('Reports page', () => {
     await user.click(await screen.findByRole('option', { name: /tobata/i }))
 
     await waitFor(() => {
-      expect(mockedFetchSales).toHaveBeenCalledWith(
+      expect(mockedFetchSales).toHaveBeenLastCalledWith(
         expect.objectContaining({ restaurantId: 2 }),
       )
     })

--- a/frontend/src/_tests_/Restaurants.test.tsx
+++ b/frontend/src/_tests_/Restaurants.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import Restaurants from './Restaurants'
+import Restaurants from '../pages/Restaurants'
 import { RestaurantContext } from '../context/RestaurantContext'
 import type { RestaurantContextType } from '../context/RestaurantContext'
 

--- a/frontend/src/_tests_/SalesEntry.test.tsx
+++ b/frontend/src/_tests_/SalesEntry.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import SalesEntry from './SalesEntry'
+import SalesEntry from '../pages/SalesEntry'
 import { submitSale } from '../lib/api'
 import { RestaurantContext } from '../context/RestaurantContext'
 import type { RestaurantContextType } from '../context/RestaurantContext'

--- a/frontend/src/_tests_/Settings.test.tsx
+++ b/frontend/src/_tests_/Settings.test.tsx
@@ -1,0 +1,146 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import Settings from '../pages/Settings'
+import { verifyCurrentPassword, changePassword } from '../lib/api'
+import { clearAuthSession } from '../lib/auth'
+
+vi.mock('../lib/api', () => ({
+  verifyCurrentPassword: vi.fn(),
+  changePassword: vi.fn(),
+}))
+
+vi.mock('../lib/auth', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../lib/auth')>()
+  return {
+    ...actual,
+    clearAuthSession: vi.fn(),
+  }
+})
+
+const mockedVerify = vi.mocked(verifyCurrentPassword)
+const mockedChange = vi.mocked(changePassword)
+const mockedClearAuth = vi.mocked(clearAuthSession)
+
+function renderSettings() {
+  return render(
+    <MemoryRouter initialEntries={['/settings']}>
+      <Routes>
+        <Route path="/settings" element={<Settings />} />
+        <Route path="/login" element={<div>Login page</div>} />
+      </Routes>
+    </MemoryRouter>,
+  )
+}
+
+describe('Settings page', () => {
+  beforeEach(() => {
+    mockedVerify.mockReset()
+    mockedChange.mockReset()
+    mockedClearAuth.mockReset()
+  })
+
+  it('shows validation error when current password is empty', async () => {
+    const user = userEvent.setup()
+    renderSettings()
+
+    await user.click(screen.getByText('Change Password'))
+    await user.click(screen.getByRole('button', { name: /verify password/i }))
+
+    expect(await screen.findByText('Current password is required.')).toBeInTheDocument()
+    expect(mockedVerify).not.toHaveBeenCalled()
+  })
+
+  it('toggles password visibility', async () => {
+    const user = userEvent.setup()
+    renderSettings()
+
+    await user.click(screen.getByText('Change Password'))
+
+    const input = screen.getByLabelText('Current Password')
+    expect(input).toHaveAttribute('type', 'password')
+
+    const toggle = screen.getByLabelText('toggle current password visibility')
+
+    await user.click(toggle)
+    expect(input).toHaveAttribute('type', 'text')
+
+    await user.click(toggle)
+    expect(input).toHaveAttribute('type', 'password')
+  })
+
+  it('moves to change step when verification succeeds', async () => {
+    const user = userEvent.setup()
+    mockedVerify.mockResolvedValue({message:"Password verified successfully."})
+
+    renderSettings()
+
+    await user.click(screen.getByText('Change Password'))
+    await user.type(screen.getByLabelText('Current Password'), 'oldpass')
+    await user.click(screen.getByRole('button', { name: /verify password/i }))
+
+    expect(await screen.findByText('Current password verified. Enter your new password below.')).toBeInTheDocument()
+    expect(screen.getByLabelText('New Password')).toBeInTheDocument()
+  })
+
+  it('shows error when verification fails', async () => {
+    const user = userEvent.setup()
+    mockedVerify.mockRejectedValue(new Error('Invalid password'))
+
+    renderSettings()
+
+    await user.click(screen.getByText('Change Password'))
+    await user.type(screen.getByLabelText('Current Password'), 'wrong')
+    await user.click(screen.getByRole('button', { name: /verify password/i }))
+
+    expect(await screen.findByText('Invalid password')).toBeInTheDocument()
+  })
+
+  it('successfully changes password and navigates to login', async () => {
+    const user = userEvent.setup()
+    mockedVerify.mockResolvedValue({message:"ok"})
+    mockedChange.mockResolvedValue({message:"ok"})
+
+    renderSettings()
+
+    // go to verify step
+    await user.click(screen.getByText('Change Password'))
+    await user.type(screen.getByLabelText('Current Password'), 'oldpass')
+    await user.click(screen.getByRole('button', { name: /verify password/i }))
+
+    // fill new password step
+    await screen.findByLabelText('New Password')
+
+    await user.type(screen.getByLabelText('New Password'), 'newpass123')
+    await user.type(screen.getByLabelText('Confirm New Password'), 'newpass123')
+
+    await user.click(screen.getByRole('button', { name: /update password/i }))
+
+    await waitFor(() => {
+      expect(mockedChange).toHaveBeenCalledWith('oldpass', 'newpass123')
+      expect(mockedClearAuth).toHaveBeenCalled()
+    })
+
+    expect(await screen.findByText('Login page')).toBeInTheDocument()
+  })
+
+  it('shows mismatch error for new passwords', async () => {
+    const user = userEvent.setup()
+    mockedVerify.mockResolvedValue({message:"ok"})
+
+    renderSettings()
+
+    await user.click(screen.getByText('Change Password'))
+    await user.type(screen.getByLabelText('Current Password'), 'oldpass')
+    await user.click(screen.getByRole('button', { name: /verify password/i }))
+
+    await screen.findByLabelText('New Password')
+
+    await user.type(screen.getByLabelText('New Password'), 'a')
+    await user.type(screen.getByLabelText('Confirm New Password'), 'b')
+
+    await user.click(screen.getByRole('button', { name: /update password/i }))
+
+    expect(await screen.findByText('New password and confirm password must match.')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/_tests_/Users.test.tsx
+++ b/frontend/src/_tests_/Users.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { Users } from './Users'
+import { Users } from '../pages/Users'
 import {
   createEmployee,
   deleteEmployee,

--- a/frontend/src/_tests_/auth.test.ts
+++ b/frontend/src/_tests_/auth.test.ts
@@ -1,4 +1,4 @@
-import { clearAuthSession, getStoredUser, getToken, isLoggedIn, setAuthSession } from './auth'
+import { clearAuthSession, getStoredUser, getToken, isLoggedIn, setAuthSession } from '../lib/auth'
 
 describe('auth helpers', () => {
   beforeEach(() => {

--- a/frontend/src/_tests_/guards.test.tsx
+++ b/frontend/src/_tests_/guards.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from '@testing-library/react'
 import { MemoryRouter, Route, Routes } from 'react-router-dom'
-import RequireAuth from './RequireAuth'
-import RequireRole from './RequireRole'
+import RequireAuth from '../features/RequireAuth'
+import RequireRole from '../features/RequireRole'
 import { AuthContext } from '../context/AuthContext'
 import type { User } from '../context/AuthTypes'
 


### PR DESCRIPTION
- Fix Reports test error caused by duplicate table cell matches and update queries to use getAllByText.  
- Add Settings page tests for more coverage.  
- Reorganize tests under a centralized src/_tests_ directory and remove outdated test file locations.  
- All tests pass.  